### PR TITLE
Fix literal string escaping

### DIFF
--- a/svgbob/src/lib.rs
+++ b/svgbob/src/lib.rs
@@ -573,6 +573,7 @@ fn exclude_escaped_text(line: &str) -> (String, Vec<(usize, String)>) {
                 buffer.push_str(&" ".repeat(end+1 - start));
                 index = end + 1;
             }
+            buffer.push_str(&line[index..line.len()]);
         }
         else{
             buffer.push_str(line);


### PR DESCRIPTION
svgbob will render strings in double quotes literally, and not replace any
characters by svg paths.

However, as mentioned in #19, there is currently a bug that the last part of a
line after the last closing double quote character is ignored:

    +-----------+---+
    | "a.to(b)" | c |
    +-----------+---+

renders like

    +-----------+---+
    | "a.to(b)"
    +-----------+---+

which is fixed in this pull request.