### PR TITLE
Add settings and CLI parameters for font and scaling

### DIFF
--- a/svgbob/src/lib.rs
+++ b/svgbob/src/lib.rs
@@ -123,7 +123,9 @@ pub struct Settings {
     /// the font family used for text (default: arial)
     pub font_family: String,
     /// the font size used for text (default: 14)
-    pub font_size: usize,
+    pub font_size: f32,
+    /// stroke width for all lines (default: 2.0)
+    pub stroke_width: f32,
 }
 
 impl Settings {
@@ -132,6 +134,14 @@ impl Settings {
         self.text_width = text_width;
         self.text_height = text_height;
     }
+
+    pub fn scale(&mut self, scale: f32) {
+        self.text_width = self.text_width * scale;
+        self.text_height = self.text_height * scale;
+        self.font_size = self.font_size * scale;
+        self.stroke_width = self.stroke_width * scale;
+    }
+
     pub fn no_optimization() -> Settings {
         let mut settings = Settings::default();
         settings.optimize = false;
@@ -181,7 +191,8 @@ impl Default for Settings {
             class: Some("bob".to_string()),
             id: None,
             font_family: "arial".to_string(),
-            font_size: 14,
+            font_size: 14.0,
+            stroke_width: 2.0,
         }
     }
 }
@@ -922,7 +933,7 @@ impl Grid {
         svg.assign("height", height);
 
         svg.append(get_defs());
-        svg.append(get_styles());
+        svg.append(get_styles(&self.settings));
         let rect = SvgRect::new()
             .set("x",0)
             .set("y",0)
@@ -963,35 +974,35 @@ fn get_defs() -> Definitions {
     defs
 }
 
-fn get_styles() -> Style {
-    let style = r#"
-    line, path {
+fn get_styles(settings: &Settings) -> Style {
+    let style = format!(r#"
+    line, path {{
       stroke: black;
-      stroke-width: 2;
+      stroke-width: {};
       stroke-opacity: 1;
       fill-opacity: 1;
       stroke-linecap: round;
       stroke-linejoin: miter;
-    }
-    circle {
+    }}
+    circle {{
       stroke: black;
-      stroke-width: 2;
+      stroke-width: {};
       stroke-opacity: 1;
       fill-opacity: 1;
       stroke-linecap: round;
       stroke-linejoin: miter;
-    }
-    circle.solid {
+    }}
+    circle.solid {{
       fill:black;
-    }
-    circle.open {
+    }}
+    circle.open {{
       fill:transparent;
-    }
-    tspan.head{
+    }}
+    tspan.head{{
         fill: none;
         stroke: none;
-    }
-    "#;
+    }}
+    "#, settings.stroke_width, settings.stroke_width);
     Style::new(style)
 }
 

--- a/svgbob/src/lib.rs
+++ b/svgbob/src/lib.rs
@@ -120,6 +120,10 @@ pub struct Settings {
     pub class: Option<String>,
     /// the id of the generated svg 
     pub id: Option<String>,
+    /// the font family used for text (default: arial)
+    pub font_family: String,
+    /// the font size used for text (default: 14)
+    pub font_size: usize,
 }
 
 impl Settings {
@@ -165,7 +169,6 @@ impl Settings {
             self.set_class(class);
         }
     }
-
 }
 
 impl Default for Settings {
@@ -176,7 +179,9 @@ impl Default for Settings {
             optimize: true,
             compact_path: true,
             class: Some("bob".to_string()),
-            id: None
+            id: None,
+            font_family: "arial".to_string(),
+            font_size: 14,
         }
     }
 }
@@ -911,8 +916,8 @@ impl Grid {
         if let Some(ref class) = self.settings.class{
             svg.assign("class", class.to_owned());
         }
-        svg.assign("font-size", 14);
-        svg.assign("font-family", "arial");
+        svg.assign("font-size", self.settings.font_size);
+        svg.assign("font-family", self.settings.font_family.to_owned());
         svg.assign("width", width);
         svg.assign("height", height);
 

--- a/svgbob_cli/src/main.rs
+++ b/svgbob_cli/src/main.rs
@@ -28,6 +28,14 @@ fn main() {
             .long("output")
             .takes_value(true)
             .help("where to write svg output [default: STDOUT]"))
+        .arg(Arg::with_name("font-family")
+             .long("font-family")
+             .takes_value(true)
+             .help("text will be rendered with this font"))
+        .arg(Arg::with_name("font-size")
+             .long("font-size")
+             .takes_value(true)
+             .help("text will be rendered with this font size"))
         .subcommand(SubCommand::with_name("build")
             .about("Batch convert files to svg.")
             .version("0.0.1")
@@ -79,7 +87,31 @@ fn main() {
         }
     }
 
-    let g = Grid::from_str(&*bob, &Settings::compact());
+    let mut settings = Settings::compact();
+
+    if let Some(font_family) = args.value_of("font-family") {
+        settings.font_family = font_family.to_string();
+    }
+
+    if let Some(font_size) = args.value_of("font-size") {
+        match font_size.parse() {
+            Ok(fs) => {
+                settings.font_size = fs;
+            }
+            Err(e) => {
+                use std::io::Write;
+                use std::process::exit;
+
+                writeln!(&mut std::io::stderr(),
+                         "Wrong font size: {}",
+                         e)
+                    .unwrap();
+                exit(1);
+            }
+        }
+    }
+
+    let g = Grid::from_str(&*bob, &settings);
     let svg = g.get_svg();
 
     if let Some(file) = args.value_of("output") {

--- a/svgbob_cli/src/main.rs
+++ b/svgbob_cli/src/main.rs
@@ -31,11 +31,19 @@ fn main() {
         .arg(Arg::with_name("font-family")
              .long("font-family")
              .takes_value(true)
-             .help("text will be rendered with this font"))
+             .help("text will be rendered with this font (default: 'arial')"))
         .arg(Arg::with_name("font-size")
              .long("font-size")
              .takes_value(true)
-             .help("text will be rendered with this font size"))
+             .help("text will be rendered with this font size (default: 14)"))
+        .arg(Arg::with_name("stroke-width")
+             .long("stroke-width")
+             .takes_value(true)
+             .help("stroke width for all lines (default: 2)"))
+        .arg(Arg::with_name("scale")
+             .long("scale")
+             .takes_value(true)
+             .help("scale the entire svg (dimensions, font size, stroke width) by this factor (default: 1)"))
         .subcommand(SubCommand::with_name("build")
             .about("Batch convert files to svg.")
             .version("0.0.1")
@@ -104,6 +112,42 @@ fn main() {
 
                 writeln!(&mut std::io::stderr(),
                          "Wrong font size: {}",
+                         e)
+                    .unwrap();
+                exit(1);
+            }
+        }
+    }
+
+    if let Some(stroke_width) = args.value_of("stroke-width") {
+        match stroke_width.parse() {
+            Ok(sw) => {
+                settings.stroke_width = sw;
+            }
+            Err(e) => {
+                use std::io::Write;
+                use std::process::exit;
+
+                writeln!(&mut std::io::stderr(),
+                         "Wrong stroke width: {}",
+                         e)
+                    .unwrap();
+                exit(1);
+            }
+        }
+    }
+
+    if let Some(scale) = args.value_of("scale") {
+        match scale.parse() {
+            Ok(s) => {
+                settings.scale(s);
+            }
+            Err(e) => {
+                use std::io::Write;
+                use std::process::exit;
+
+                writeln!(&mut std::io::stderr(),
+                         "Wrong scale: {}",
                          e)
                     .unwrap();
                 exit(1);

--- a/svgbob_cli/src/main.rs
+++ b/svgbob_cli/src/main.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 use std::error::Error;
 use std::io::Read;
 use std::process::exit;
+use std::str::FromStr;
 
 fn main() {
     use clap::{Arg, App, SubCommand};
@@ -101,58 +102,16 @@ fn main() {
         settings.font_family = font_family.to_string();
     }
 
-    if let Some(font_size) = args.value_of("font-size") {
-        match font_size.parse() {
-            Ok(fs) => {
-                settings.font_size = fs;
-            }
-            Err(e) => {
-                use std::io::Write;
-                use std::process::exit;
-
-                writeln!(&mut std::io::stderr(),
-                         "Wrong font size: {}",
-                         e)
-                    .unwrap();
-                exit(1);
-            }
-        }
+    if let Some(font_size) = parse_value_of(&args, "font-size") {
+        settings.font_size = font_size;
     }
 
-    if let Some(stroke_width) = args.value_of("stroke-width") {
-        match stroke_width.parse() {
-            Ok(sw) => {
-                settings.stroke_width = sw;
-            }
-            Err(e) => {
-                use std::io::Write;
-                use std::process::exit;
-
-                writeln!(&mut std::io::stderr(),
-                         "Wrong stroke width: {}",
-                         e)
-                    .unwrap();
-                exit(1);
-            }
-        }
+    if let Some(stroke_width) = parse_value_of(&args, "stroke-width") {
+        settings.stroke_width = stroke_width;
     }
 
-    if let Some(scale) = args.value_of("scale") {
-        match scale.parse() {
-            Ok(s) => {
-                settings.scale(s);
-            }
-            Err(e) => {
-                use std::io::Write;
-                use std::process::exit;
-
-                writeln!(&mut std::io::stderr(),
-                         "Wrong scale: {}",
-                         e)
-                    .unwrap();
-                exit(1);
-            }
-        }
+    if let Some(scale) = parse_value_of(&args, "scale") {
+        settings.scale(scale);
     }
 
     let g = Grid::from_str(&*bob, &settings);
@@ -173,6 +132,23 @@ fn main() {
     } else {
         println!("{}", svg);
     }
+}
+
+fn parse_value_of<T: FromStr>(args: &ArgMatches, arg_name: &str) -> Option<T> where <T as std::str::FromStr>::Err: std::fmt::Display {
+    return args.value_of(arg_name).and_then(|arg| match arg.parse::<T>() {
+        Ok(a) => Some(a),
+        Err(e) => {
+            use std::io::Write;
+            use std::process::exit;
+
+            writeln!(&mut std::io::stderr(),
+                        "Illegal value for argument {}: {}",
+                        arg_name,
+                        e)
+                .unwrap();
+            exit(1);
+        }
+    });
 }
 
 // Batch convert files to svg


### PR DESCRIPTION
Adds the following command line parameters:

    --font-family <font-family>      text will be rendered with this font (default: 'arial')
    --font-size <font-size>          text will be rendered with this font size (default: 14)
    --stroke-width <stroke-width>    stroke width for all lines (default: 2)
    --scale <scale>                  scale the entire svg (dimensions, font size, stroke width) by this factor
                                     (default: 1)

This allows to change `font-family`, `font-size` and `stroke-width` directly from the command line. The previously hard-coded settings are kept as default values. The `scale` parameter will scale all dimensions (grid size, font size, stroke width) by a given factor.

I use Svgbob together with Pandoc (see https://github.com/fmthoma/pandoc-svgbob) for illustrations on presentation slides, where I'd like to have a monospace font and larger overall graphics.