### PR TITLE
Fix FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-patreon:ivanceras 
+patreon: ivanceras 


### PR DESCRIPTION
Before this fix, yaml parses this file as a string (`"patreon:ivanceras"`) instead of an object (`{ "patreon": "invanceras" }`).

![github error](https://user-images.githubusercontent.com/11488886/80107675-97bc0080-85a5-11ea-9f58-55caa71838f0.png)
