### PR TITLE
Fix stray prints

### DIFF
--- a/svgbob/src/buffer/cell_buffer.rs
+++ b/svgbob/src/buffer/cell_buffer.rs
@@ -505,9 +505,7 @@ impl From<StringBuffer> for CellBuffer {
         let mut buffer = CellBuffer::new();
         for (y, line) in sb.iter().enumerate() {
             let line_str = String::from_iter(line);
-            println!("line_str: {:?}", line_str);
             let (escaped_text, unescaped) = Self::escape_line(y, &line_str);
-            println!("unescaped: {:?}", unescaped);
             buffer.escaped_text.extend(escaped_text);
 
             for (x, ch) in unescaped.chars().enumerate() {


### PR DESCRIPTION
These are causing invalid svg to be outputted.

Introduced by https://github.com/ivanceras/svgbob/commit/a2c13a56e1fbd2a458c90bbb97bb858adc20a5ce.