### PR TITLE
Make --scale a multiplier of the default scale

### DIFF
--- a/svgbob_cli/src/main.rs
+++ b/svgbob_cli/src/main.rs
@@ -129,8 +129,10 @@ fn main() {
         settings.stroke_width = stroke_width;
     }
 
-    if let Some(scale) = parse_value_of(&args, "scale") {
-        settings.scale = scale;
+    let scale : Option<f32> = parse_value_of(&args, "scale");
+    match scale {
+        Some(s) => { settings.scale *= s; },
+        _ => {}
     }
 
     let svg = svgbob::to_svg_with_settings(&*bob, &settings);


### PR DESCRIPTION
The help for the `--scale` option states the default value is 1. This is not the case though (current default is 8.0) which leads to the surprising result that without a scale argument the output width will be `x` and with, for instance `--scale 2` the output width will be `x / 4` instead of `x * 2`.

This change makes the CLI scale argument a multiplier of the default scale instead of overwriting the default scale.