### PR TITLE
add macron/overline

### DIFF
--- a/packages/svgbob/src/map/unicode_map.rs
+++ b/packages/svgbob/src/map/unicode_map.rs
@@ -98,6 +98,11 @@ pub static UNICODE_FRAGMENTS: Lazy<BTreeMap<char, Vec<Fragment>>> =
         let unit8 = Cell::unit(8);
 
         let map = vec![
+            // TODO: add Arc connections, like underscore, for macron/overline
+            // overline, U+203E
+            ('‾', vec![line(a, e)]),
+            // macron, U+00AF
+            ('¯', vec![line(a, e)]),
             // dash
             ('─', vec![line(k, o)]),
             // en dash, E2 80 93


### PR DESCRIPTION
Adds the overline (‾) and macron (¯) characters as a line connecting points A and E on the character cell grid.

Quick and lazy, but should work as expected. Should add appropriate arc connections and strength signals in the future - see underscore in ascii_map.rs